### PR TITLE
Set logo height

### DIFF
--- a/code/build/js/federal/70logo.js
+++ b/code/build/js/federal/70logo.js
@@ -83,9 +83,9 @@ const logo = {
 
     // let width = Math.max(50, draw.width() * logo.logoinfo.widthFraction);
     const width = draw.width() * logo.logoinfo.widthFraction;
-    logo.svg.size(width);
-    let x; let
-      y;
+    logo.svg.size(width, null);
+    let x;
+    let y;
 
     switch (logo.logoinfo.position) {
       case 'bottomleft':

--- a/code/build/js/nrw/70logo.js
+++ b/code/build/js/nrw/70logo.js
@@ -35,9 +35,9 @@ const logo = {
     if (!logo.isLoaded) return false;
 
     const width = Math.max(50, draw.width() * logo.logoinfo.widthFraction);
-    logo.svg.size(width);
-    let x; let
-      y;
+    logo.svg.size(width, null);
+    let x;
+    let y;
 
     switch (logo.logoinfo.position) {
       case 'bottomleft':


### PR DESCRIPTION
Looks like that Firefox doesn't display the logo if the height is 0.
Passing "null" to size() will resize the image proportional.