### PR TITLE
Twitter Stream Format wird abgeschnitten

### DIFF
--- a/code/dist/ini/picturesizes.ini
+++ b/code/dist/ini/picturesizes.ini
@@ -19,7 +19,7 @@ Story = 1080x1920
 
 [Twitter]
 Titel = 1500x500
-In Stream = 440x220
+In Stream = 1600x900
 
 [Flyeralarm]
 Postkarte hoch = 1500x2102:95


### PR DESCRIPTION
Das Format 440x220 wird von Twitter im Stream beschnitten. Laut Dokumentation ist 16:9 die Grenze. Ich habe daher mit 1600x900 gute Erfahrung gemacht und die höhere Auflösung sieht auf aktuellen Displays auch besser aus. Ich erstelle die Bilder eigentlich mit 3200x1800